### PR TITLE
feat: add reporting of visible range

### DIFF
--- a/lib/src/extent_manager.dart
+++ b/lib/src/extent_manager.dart
@@ -92,22 +92,60 @@ class ExtentManager with ChangeNotifier {
   bool _layoutInProgress = false;
   bool _isModified = false;
 
+  bool _didReportVisibleChildren = false;
+  bool _didReportUnobstructedVisibleChildren = false;
+
   void performLayout(VoidCallback layout) {
     assert(!_layoutInProgress);
     _layoutInProgress = true;
     _isModified = false;
+    _didReportVisibleChildren = false;
+    _didReportUnobstructedVisibleChildren = false;
     _beforeCorrection = 0.0;
     _afterCorrection = 0.0;
+
     try {
       layout();
     } finally {
       assert(_layoutInProgress);
+      // Not reporting children means there are no visible children - set the
+      // visible range to null.
+      if (!_didReportVisibleChildren) {
+        reportVisibleChildren(null);
+      }
+      if (!_didReportUnobstructedVisibleChildren) {
+        reportUnobstructedVisibleChildren(null);
+      }
       _layoutInProgress = false;
       if (_isModified) {
         notifyListeners();
       }
     }
   }
+
+  void reportVisibleChildren((int, int)? range) {
+    assert(_layoutInProgress);
+    if (_visibleRange != range) {
+      _visibleRange = range;
+      _isModified = true;
+    }
+    _didReportVisibleChildren = true;
+  }
+
+  void reportUnobstructedVisibleChildren((int, int)? range) {
+    assert(_layoutInProgress);
+    if (_unobstructedVisibleRange != range) {
+      _unobstructedVisibleRange = range;
+      _isModified = true;
+    }
+    _didReportUnobstructedVisibleChildren = true;
+  }
+
+  (int, int)? get visibleRange => _visibleRange;
+  (int, int)? _visibleRange;
+
+  (int, int)? get unobstructedVisibleRange => _unobstructedVisibleRange;
+  (int, int)? _unobstructedVisibleRange;
 
   int get numberOfItems => _extentList.length;
 

--- a/lib/src/super_sliver_list.dart
+++ b/lib/src/super_sliver_list.dart
@@ -130,6 +130,19 @@ class ListController extends ChangeNotifier {
     }
   }
 
+  /// Returns the range of items indices currently visible in the viewport.
+  (int, int)? get visibleRange {
+    assert(_delegate != null, "ListController is not attached.");
+    return _delegate!.visibleRange;
+  }
+
+  /// Returns range of items indices currently visible in the viewport
+  /// unobstructed by sticky headers or other obstructions.
+  (int, int)? get unobstructedVisibleRange {
+    assert(_delegate != null, "ListController is not attached.");
+    return _delegate!.unobstructedVisibleRange;
+  }
+
   /// Returns the total number of items in the list.
   int get numberOfItems {
     assert(_delegate != null, "ListController is not attached.");

--- a/test/super_sliver_list_test.dart
+++ b/test/super_sliver_list_test.dart
@@ -586,6 +586,89 @@ void main() async {
       // Failing this likely means the child manager is not aware of underflow.
       expect(find.text("Tile 0"), findsOneWidget);
     });
+    testWidgets("visible range", (tester) async {
+      final list = _SliverListConfiguration.generate(
+        slivers: 3,
+        itemsPerSliver: (_) => 6,
+        itemHeight: (_, __) => 100,
+        viewportHeight: 500,
+        pinnedHeaderHeight: (i) => i == 0 ? 100 : 0,
+      );
+      final controller = ScrollController();
+      await tester.pumpWidget(
+        _buildSliverList(
+          list,
+          controller: controller,
+          preciseLayout: false,
+        ),
+      );
+      expect(list.slivers[0].listController.visibleRange, equals((0, 3)));
+      expect(list.slivers[0].listController.unobstructedVisibleRange,
+          equals((0, 3)));
+      expect(list.slivers[1].listController.visibleRange, isNull);
+
+      controller.jumpTo(100);
+      await tester.pump();
+
+      expect(list.slivers[0].listController.visibleRange, equals((0, 4)));
+      expect(list.slivers[0].listController.unobstructedVisibleRange,
+          equals((1, 4)));
+      expect(list.slivers[1].listController.visibleRange, isNull);
+
+      controller.jumpTo(199);
+      await tester.pump();
+
+      expect(list.slivers[0].listController.visibleRange, equals((0, 5)));
+      expect(list.slivers[0].listController.unobstructedVisibleRange,
+          equals((1, 5)));
+      expect(list.slivers[1].listController.visibleRange, isNull);
+
+      controller.jumpTo(200);
+      await tester.pump();
+
+      expect(list.slivers[0].listController.visibleRange, equals((1, 5)));
+      expect(list.slivers[0].listController.unobstructedVisibleRange,
+          equals((2, 5)));
+      expect(list.slivers[1].listController.visibleRange, isNull);
+
+      controller.jumpTo(299);
+      await tester.pump();
+
+      expect(list.slivers[0].listController.visibleRange, equals((1, 5)));
+      expect(list.slivers[0].listController.unobstructedVisibleRange,
+          equals((2, 5)));
+      expect(list.slivers[1].listController.visibleRange, equals((0, 0)));
+      expect(list.slivers[1].listController.unobstructedVisibleRange,
+          equals((0, 0)));
+
+      controller.jumpTo(300);
+      await tester.pump();
+
+      expect(list.slivers[0].listController.visibleRange, equals((2, 5)));
+      expect(list.slivers[0].listController.unobstructedVisibleRange,
+          equals((3, 5)));
+      expect(list.slivers[1].listController.visibleRange, equals((0, 0)));
+      expect(list.slivers[1].listController.unobstructedVisibleRange,
+          equals((0, 0)));
+
+      controller.jumpTo(600);
+      await tester.pump();
+
+      expect(list.slivers[0].listController.visibleRange, equals((5, 5)));
+      expect(list.slivers[0].listController.unobstructedVisibleRange, isNull);
+      expect(list.slivers[1].listController.visibleRange, equals((0, 3)));
+      expect(list.slivers[1].listController.unobstructedVisibleRange,
+          equals((0, 3)));
+
+      controller.jumpTo(700);
+      await tester.pump();
+
+      expect(list.slivers[0].listController.visibleRange, isNull);
+      expect(list.slivers[0].listController.unobstructedVisibleRange, isNull);
+      expect(list.slivers[1].listController.visibleRange, equals((0, 4)));
+      expect(list.slivers[1].listController.unobstructedVisibleRange,
+          equals((1, 4)));
+    });
     testWidgets("delay populating cache area enabled", (tester) async {
       final keys0 = List.generate(50, (index) => GlobalKey());
       final keys1 = List.generate(1, (index) => GlobalKey());


### PR DESCRIPTION
This introduces `visibleRange` and `unobstructedVisibleRange` properties on `ListController` which can be used to query range of visible item indices for each `SuperSliverList`.

Fixes https://github.com/superlistapp/super_sliver_list/issues/23