### PR TITLE
fix: SuperSliverList exceeding max layout cycles

### DIFF
--- a/lib/src/render_object.dart
+++ b/lib/src/render_object.dart
@@ -754,6 +754,7 @@ class RenderSuperSliverList extends RenderSliverMultiBoxAdaptor
       final correction = paintExtentOf(box) - previousExtent;
       _log.finest(
         "Adding preceding child with index ${indexOf(box)} "
+        "extent: ${paintExtentOf(box)} "
         "(${correction.format()} correction)",
       );
       _shiftLayoutOffsets(childAfter(box), correction);
@@ -764,7 +765,16 @@ class RenderSuperSliverList extends RenderSliverMultiBoxAdaptor
               constraints.viewportMainAxisExtent) {
         scrollCorrection += correction;
       }
-      correctedStartOffset += correction;
+
+      // If start offset is 0, we must end up at initial item, so do not correct the
+      // start offset.
+      // If start offset > 0 we care about filling up the cache area, so correct the
+      // offset depending on the extent of the child. TODO(knopp): It might be enough
+      // to just ensure that we have a single completely hidden child in the cache
+      // area. See https://github.com/flutter/flutter/issues/128601
+      if (startOffset > 0) {
+        correctedStartOffset += correction;
+      }
     }
 
     // Additional correction: first child is not at the very beginning

--- a/lib/src/render_object.dart
+++ b/lib/src/render_object.dart
@@ -734,9 +734,12 @@ class RenderSuperSliverList extends RenderSliverMultiBoxAdaptor
           childScrollOffset(firstVisible)! - firstVisibleLayoutOffset!;
     }
 
+    // Start offset with applied scroll correction.
+    var correctedStartOffset = startOffset + scrollCorrection;
+
     // Adding preceding children.
     while ((indexOf(firstChild!) > 0 &&
-            childScrollOffset(firstChild!)! > startOffset + scrollCorrection) ||
+            childScrollOffset(firstChild!)! > correctedStartOffset) ||
         (_childScrollOffsetEstimation != null &&
             indexOf(firstChild!) > _childScrollOffsetEstimation!.index)) {
       final prevOffset = childScrollOffset(firstChild!)!;
@@ -761,6 +764,7 @@ class RenderSuperSliverList extends RenderSliverMultiBoxAdaptor
               constraints.viewportMainAxisExtent) {
         scrollCorrection += correction;
       }
+      correctedStartOffset += correction;
     }
 
     // Additional correction: first child is not at the very beginning


### PR DESCRIPTION
Happens when scrolling at the end of list when items are smaller than estimation