### PR TITLE
return future from ListController.animateToItem

### DIFF
--- a/lib/src/animate_to_item.dart
+++ b/lib/src/animate_to_item.dart
@@ -25,10 +25,10 @@ class AnimateToItem {
 
   double lastPosition = 0.0;
 
-  void animate() {
+  TickerFuture animate() {
     final index = this.index();
     if (index == null) {
-      return;
+      return TickerFuture.complete();
     }
     final start = position.pixels;
     final estimatedTarget = extentManager.getOffsetToReveal(
@@ -83,6 +83,6 @@ class AnimateToItem {
       }
       position.jumpTo(jumpPosition);
     });
-    controller.forward();
+    return controller.forward();
   }
 }

--- a/lib/src/super_sliver_list.dart
+++ b/lib/src/super_sliver_list.dart
@@ -124,26 +124,28 @@ class ListController extends ChangeNotifier {
   /// edge of the viewport. If the value is 0.5, the item will be positioned in
   /// the middle of the viewport. If the value is 1.0, the item will be
   /// positioned at the trailing edge of the viewport.
-  void animateToItem({
+  Future<void> animateToItem({
     required ValueGetter<int?> index,
     required ScrollController scrollController,
     required double alignment,
     required Duration Function(double estimatedDistance) duration,
     required Curve Function(double estimatedDistance) curve,
     Rect? rect,
-  }) {
+  }) async {
     assert(_delegate != null, "ListController is not attached.");
-    for (final position in scrollController.positions) {
-      AnimateToItem(
-        extentManager: _delegate!,
-        index: index,
-        alignment: alignment,
-        rect: rect,
-        position: position,
-        curve: curve,
-        duration: duration,
-      ).animate();
-    }
+
+    await Future.wait([
+      for (final position in scrollController.positions)
+        AnimateToItem(
+          extentManager: _delegate!,
+          index: index,
+          alignment: alignment,
+          rect: rect,
+          position: position,
+          curve: curve,
+          duration: duration,
+        ).animate(),
+    ]);
   }
 
   /// Returns the range of items indices currently visible in the viewport.

--- a/test/super_sliver_list_test.dart
+++ b/test/super_sliver_list_test.dart
@@ -1279,6 +1279,150 @@ void main() async {
       expect(detached2, 0);
       expect(controller2.isAttached, isTrue);
     });
+    testWidgets("jumpToItem", (tester) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      final listController = ListController();
+      addTearDown(listController.dispose);
+      final configuration = SliverListConfiguration.generate(
+        slivers: 1,
+        itemsPerSliver: (_) => 20,
+        itemHeight: (_, __) => 300,
+        viewportHeight: 500,
+      );
+      await tester.pumpWidget(_buildSliverList(
+        configuration,
+        controller: controller,
+        listController: listController,
+        preciseLayout: true,
+      ));
+      await tester.pumpAndSettle();
+      expect(listController.isAttached, isTrue);
+
+      listController.jumpToItem(
+        index: 10,
+        scrollController: controller,
+        alignment: 0.0
+      );
+      await tester.pump();
+      expect(listController.visibleRange?.$1, 10);
+      expect(controller.offset, 3000);
+    });
+    testWidgets("animateToItem", (tester) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      final listController = ListController();
+      addTearDown(listController.dispose);
+      final configuration = SliverListConfiguration.generate(
+        slivers: 1,
+        itemsPerSliver: (_) => 20,
+        itemHeight: (_, __) => 300,
+        viewportHeight: 500,
+      );
+      await tester.pumpWidget(_buildSliverList(
+        configuration,
+        controller: controller,
+        listController: listController,
+        preciseLayout: true,
+      ));
+      await tester.pumpAndSettle();
+      expect(listController.isAttached, isTrue);
+
+      const duration = Duration(milliseconds: 500);
+      const curve = Curves.linear;
+      listController.animateToItem(
+        index: () => 10,
+        scrollController: controller,
+        alignment: 0.0,
+        duration: (_) => duration,
+        curve: (_) => curve,
+      );
+      await tester.pump();
+      await tester.pump(duration ~/ 2);
+      expect(controller.offset, curve.transform(0.5) * 3000);
+      await tester.pumpAndSettle();
+      expect(listController.visibleRange?.$1, 10);
+      expect(controller.offset, 3000);
+    });
+    testWidgets("animateToItem returns future that completes when animation completes", (tester) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      final listController = ListController();
+      addTearDown(listController.dispose);
+      final configuration = SliverListConfiguration.generate(
+        slivers: 1,
+        itemsPerSliver: (_) => 20,
+        itemHeight: (_, __) => 300,
+        viewportHeight: 500,
+      );
+      await tester.pumpWidget(_buildSliverList(
+        configuration,
+        controller: controller,
+        listController: listController,
+        preciseLayout: true,
+      ));
+      await tester.pumpAndSettle();
+      expect(listController.isAttached, isTrue);
+
+      const duration = Duration(milliseconds: 500);
+      const curve = Curves.linear;
+      var animationComplete = false;
+      listController.animateToItem(
+        index: () => 10,
+        scrollController: controller,
+        alignment: 0.0,
+        duration: (_) => duration,
+        curve: (_) => curve,
+      ).whenComplete(() {
+        animationComplete = true;
+      });
+      await tester.pump();
+      await tester.pump(duration ~/ 2);
+      expect(animationComplete, false);
+      await tester.pumpAndSettle();
+      expect(animationComplete, true);
+    });
+    testWidgets("animateToItem future does not complete when animation canceled", (tester) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      final listController = ListController();
+      addTearDown(listController.dispose);
+      final configuration = SliverListConfiguration.generate(
+        slivers: 1,
+        itemsPerSliver: (_) => 20,
+        itemHeight: (_, __) => 300,
+        viewportHeight: 500,
+      );
+      await tester.pumpWidget(_buildSliverList(
+        configuration,
+        controller: controller,
+        listController: listController,
+        preciseLayout: true,
+      ));
+      await tester.pumpAndSettle();
+      expect(listController.isAttached, isTrue);
+
+      const duration = Duration(milliseconds: 500);
+      const curve = Curves.linear;
+      int? index = 10;
+      var animationComplete = false;
+      listController.animateToItem(
+        index: () => index,
+        scrollController: controller,
+        alignment: 0.0,
+        duration: (_) => duration,
+        curve: (_) => curve,
+      ).whenComplete(() {
+        animationComplete = true;
+      });
+      await tester.pump();
+      await tester.pump(duration ~/ 2);
+      expect(animationComplete, false);
+      index = null;
+      await tester.pumpAndSettle();
+      expect(animationComplete, false);
+      expect(controller.offset, lessThan(3000));
+    });
   });
 }
 


### PR DESCRIPTION
A different take on https://github.com/superlistapp/super_sliver_list/pull/82.

I also added tests for `ListController#jumpToItem` and `ListController#animateToItem`.

Current implementation follows `TickerFuture`'s behavior by not completing if animation is canceled.
I could see 2 reasonable alternatives:
a) complete the future returned by `animateToItem` when animation completes or is canceled
b) instead of returning a `Future<void>`, return a status enum indicating if animation completed or was canceled

Our use case for this functionality is to be able to call a callback when the `animateToItem` completes.