### PR TITLE
animation cancellation

### DIFF
--- a/lib/src/animate_to_item.dart
+++ b/lib/src/animate_to_item.dart
@@ -13,6 +13,7 @@ class AnimateToItem {
     required this.position,
     required this.duration,
     required this.curve,
+    required this.canceler,
   });
 
   final ExtentManager extentManager;
@@ -22,6 +23,7 @@ class AnimateToItem {
   final ScrollPosition position;
   final Duration Function(double estimatedDistance) duration;
   final Curve Function(double estimatedDistance) curve;
+  final Listenable canceler;
 
   double lastPosition = 0.0;
 
@@ -42,21 +44,27 @@ class AnimateToItem {
       vsync: position.context.vsync,
       duration: duration(estimatedDistance),
     );
-    controller.addStatusListener((status) {
-      if (status == AnimationStatus.completed) {
-        controller.dispose();
-      }
-    });
     final animation = CurvedAnimation(
       parent: controller,
       curve: curve(estimatedDistance),
     );
+    void dispose() {
+      controller.dispose();
+      animation.dispose();
+      canceler.removeListener(dispose);
+    }
+
+    canceler.addListener(dispose);
+    controller.addStatusListener((status) {
+      if (status == AnimationStatus.completed) {
+        dispose();
+      }
+    });
     animation.addListener(() {
       final value = animation.value;
       final index = this.index();
       if (index == null) {
-        controller.stop();
-        controller.dispose();
+        dispose();
         return;
       }
       var targetPosition = extentManager.getOffsetToReveal(

--- a/lib/src/super_sliver_list.dart
+++ b/lib/src/super_sliver_list.dart
@@ -71,6 +71,8 @@ class ListController extends ChangeNotifier {
   /// Returns `true` if the controller is attached to a [SuperSliverList].
   bool get isAttached => _delegate != null;
 
+  _CancelToken? _animationCanceler;
+
   /// Immediately positions the scroll view such that the item at [index] is
   /// revealed in the viewport.
   ///
@@ -90,6 +92,8 @@ class ListController extends ChangeNotifier {
     Rect? rect,
   }) {
     assert(_delegate != null, "ListController is not attached.");
+    _animationCanceler?.cancel();
+    _animationCanceler = null;
     final offset = getOffsetToReveal(index, alignment, rect: rect);
     if (offset.isFinite) {
       final minExtent = scrollController.position.minScrollExtent;
@@ -133,6 +137,10 @@ class ListController extends ChangeNotifier {
     Rect? rect,
   }) {
     assert(_delegate != null, "ListController is not attached.");
+
+    _animationCanceler?.cancel();
+    final canceler = _animationCanceler = _CancelToken();
+
     for (final position in scrollController.positions) {
       AnimateToItem(
         extentManager: _delegate!,
@@ -142,6 +150,7 @@ class ListController extends ChangeNotifier {
         position: position,
         curve: curve,
         duration: duration,
+        canceler: canceler,
       ).animate();
     }
   }
@@ -270,6 +279,8 @@ class ListController extends ChangeNotifier {
     if (_delegate == delegate) {
       _delegate?.removeListener(notifyListeners);
       _delegate = null;
+      _animationCanceler?.cancel();
+      _animationCanceler = null;
       onDetached?.call();
     }
   }
@@ -596,4 +607,15 @@ class _TimeSuperSliverListLayoutBudget extends SuperSliverListLayoutBudget {
 
 double _defaultEstimateExtent(int? index, double crossAxisExtent) {
   return 100.0;
+}
+
+class _CancelToken with ChangeNotifier {
+  bool isCanceled = false;
+
+  void cancel() {
+    if (!isCanceled) {
+      isCanceled = true;
+      notifyListeners();
+    }
+  }
 }

--- a/lib/src/super_sliver_list.dart
+++ b/lib/src/super_sliver_list.dart
@@ -616,6 +616,7 @@ class _CancelToken with ChangeNotifier {
     if (!isCanceled) {
       isCanceled = true;
       notifyListeners();
+      dispose();
     }
   }
 }

--- a/test/super_sliver_list_test.dart
+++ b/test/super_sliver_list_test.dart
@@ -1279,6 +1279,162 @@ void main() async {
       expect(detached2, 0);
       expect(controller2.isAttached, isTrue);
     });
+    testWidgets("animations canceled when ListController detached", (tester) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+
+      int attached = 0;
+      int detached = 0;
+      final listController = ListController(
+        onAttached: () {
+          ++attached;
+        },
+        onDetached: () {
+          ++detached;
+        },
+      );
+      addTearDown(listController.dispose);
+      final configuration = SliverListConfiguration.generate(
+        slivers: 1,
+        itemsPerSliver: (_) => 20,
+        itemHeight: (_, __) => 300,
+        viewportHeight: 500,
+        addGlobalKey: true,
+      );
+      await tester.pumpWidget(_buildSliverList(
+        configuration,
+        controller: controller,
+        listController: listController,
+        preciseLayout: false,
+      ));
+      await tester.pumpAndSettle();
+      expect(attached, 1);
+      expect(detached, 0);
+      expect(listController.isAttached, isTrue);
+
+      listController.animateToItem(
+        index: () => 10,
+        scrollController: controller,
+        alignment: 0.0,
+        duration: (estimatedDistance) => const Duration(milliseconds: 1000),
+        curve: (estimatedDistance) => Curves.linear,
+      );
+
+      await tester.pump(const Duration(milliseconds: 500));
+
+      // will throw if there are any leaked Tickers
+      await tester.pumpWidget(const SizedBox.shrink());
+      expect(attached, 1);
+      expect(detached, 1);
+      expect(listController.isAttached, false);
+    });
+    testWidgets("animations canceled when new animation started", (tester) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      final listController = ListController();
+      addTearDown(listController.dispose);
+      final configuration = SliverListConfiguration.generate(
+        slivers: 1,
+        itemsPerSliver: (_) => 20,
+        itemHeight: (_, __) => 300,
+        viewportHeight: 500,
+        addGlobalKey: true,
+      );
+      await tester.pumpWidget(_buildSliverList(
+        configuration,
+        controller: controller,
+        listController: listController,
+        preciseLayout: true,
+      ));
+      await tester.pumpAndSettle();
+
+      final offsets = <double>[];
+      controller.addListener(() {
+        offsets.add(controller.offset);
+      });
+
+      listController.animateToItem(
+        index: () => 10,
+        scrollController: controller,
+        alignment: 0.0,
+        duration: (estimatedDistance) => const Duration(milliseconds: 1000),
+        curve: (estimatedDistance) => Curves.linear,
+      );
+
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      listController.animateToItem(
+        index: () => 0,
+        scrollController: controller,
+        alignment: 0.0,
+        duration: (estimatedDistance) => const Duration(milliseconds: 1000),
+        curve: (estimatedDistance) => Curves.linear,
+      );
+
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      // half way to 10, half way back to 0, back to 0
+      // without cancellation, first animation keeps running
+      // and offsets instead is
+      // [1500.0, 3000.0, 750.0, 3000.0, 750.0, 3000.0, 0.0]
+      expect(offsets, [1500.0, 750.0, 0.0]);
+    });
+    testWidgets("animations canceled when jumpToItem called", (tester) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      final listController = ListController();
+      addTearDown(listController.dispose);
+      final configuration = SliverListConfiguration.generate(
+        slivers: 1,
+        itemsPerSliver: (_) => 20,
+        itemHeight: (_, __) => 300,
+        viewportHeight: 500,
+        addGlobalKey: true,
+      );
+      await tester.pumpWidget(_buildSliverList(
+        configuration,
+        controller: controller,
+        listController: listController,
+        preciseLayout: true,
+      ));
+      await tester.pumpAndSettle();
+
+      final offsets = <double>[];
+      controller.addListener(() {
+        offsets.add(controller.offset);
+      });
+
+      listController.animateToItem(
+        index: () => 10,
+        scrollController: controller,
+        alignment: 0.0,
+        duration: (estimatedDistance) => const Duration(milliseconds: 1000),
+        curve: (estimatedDistance) => Curves.linear,
+      );
+
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      listController.jumpToItem(
+        index: 0,
+        scrollController: controller,
+        alignment: 0.0,
+      );
+
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      // half way to 10, back to 0
+      // without cancellation, first animation keeps running
+      // and offsets instead is
+      // [1500.0, 0.0, 1500.0, 3000.0]
+      expect(offsets, [1500.0, 0.0]);
+    });
   });
 }
 


### PR DESCRIPTION
A different take on https://github.com/superlistapp/super_sliver_list/pull/76.

Cancels any ongoing animations when
- `ListController` is detached from `Scrollable`
- `animateToItem`
- `jumpToItem` is called

Should resolve https://github.com/superlistapp/super_sliver_list/issues/65 and potentially  https://github.com/superlistapp/super_sliver_list/issues/88.

Includes tests demonstrating and fixing the existing issues with conflicting animations.