### PR TITLE
expose offsetForIndex from ListController

### DIFF
--- a/lib/src/super_sliver_list.dart
+++ b/lib/src/super_sliver_list.dart
@@ -171,6 +171,12 @@ class ListController extends ChangeNotifier {
     return _delegate!.numberOfItemsWithEstimatedExtent;
   }
 
+  /// Returns the offset of the item at [index].
+  double offsetForIndex(int index) {
+    assert(_delegate != null, "ListController is not attached.");
+    return _delegate!.offsetForIndex(index);
+  }
+
   /// Returns the extent of the item at [index].
   ///
   /// If `isEstimated` is `true`, the returned extent is an estimate and may not


### PR DESCRIPTION
similar to exposing `extentForIndex`.

My use case is being able to use `offsetForIndex` (plus some other info) to determine if the first/last items from `visibleRange` are completely visible or only partially visible.